### PR TITLE
fix(website): 下载锚点位置

### DIFF
--- a/website/src/components/Download.astro
+++ b/website/src/components/Download.astro
@@ -108,9 +108,9 @@ const downloads = [
 const sourceConfig = JSON.stringify(DOWNLOAD_SOURCES);
 ---
 
-<section id="download" class="download" data-source-config={sourceConfig} data-default-source={defaultSource}>
+<section class="download" data-source-config={sourceConfig} data-default-source={defaultSource}>
   <div class="container">
-    <h2 class="section-title fade-in">{t.download.title}</h2>
+    <h2 id="download" class="section-title fade-in">{t.download.title}</h2>
     <p class="section-subtitle fade-in fade-in-delay-1">{t.download.subtitle}</p>
 
     <div class="version-info fade-in fade-in-delay-1">
@@ -219,6 +219,11 @@ const sourceConfig = JSON.stringify(DOWNLOAD_SOURCES);
     position: relative;
     padding: var(--spacing-section) 0;
     background: var(--color-bg-primary);
+  }
+
+  /* 锚点打在标题上，避免停在大段 padding 上显得空 */
+  .download .section-title {
+    scroll-margin-top: 5.5rem;
   }
   
   .download::before {


### PR DESCRIPTION
## Summary
- `#download` 锚点改到标题上，跳转后不再偏高留白

## Deploy
合并后触发 Deploy Website。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low risk for anchor UX, but moving `id="download"` off the `<section>` can break download-source tab logic that still resolves config via `getElementById('download')`.
> 
> **Overview**
> In-page links to **`#download`** (hero, header CTA, etc.) now land on the download **section title** instead of the top of the padded `<section>`, so the viewport no longer stops on empty space above the heading.
> 
> The **`id="download"`** moves from the outer `<section class="download">` to the `<h2 class="section-title">`, and **`scroll-margin-top: 5.5rem`** is added on that title so the fixed header does not cover it after scroll.
> 
> **Note for reviewers:** the client script still calls `document.getElementById('download')` to read `data-source-config` / `data-default-source` from the section; with the id on the heading, that lookup may no longer see those attributes unless the script is pointed at `.download` or similar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18837c318c02c54e7eaab3d815120a9db940f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->